### PR TITLE
fix: make start scripts path portable

### DIFF
--- a/start_dashboard_ui.sh
+++ b/start_dashboard_ui.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd /home/user/mm-market-tools
-python3 /home/user/mm-market-tools/web_refresh_server.py --host 127.0.0.1 --port 8000
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+python3 web_refresh_server.py --host 127.0.0.1 --port 8000

--- a/start_refresh_ui.sh
+++ b/start_refresh_ui.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd /home/user/mm-market-tools
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
 python3 web_refresh_server.py --host 127.0.0.1 --port 8040


### PR DESCRIPTION
## Summary
- replace hardcoded `/home/user/mm-market-tools` in both start scripts
- compute repo path dynamically via `SCRIPT_DIR`
- keep the change isolated to the two shell entrypoints from #22

## Verification
- `bash -n start_dashboard_ui.sh`
- `bash -n start_refresh_ui.sh`
- executed both scripts from `/tmp` with a stub `python3` and confirmed they `cd` into the repo before invoking `web_refresh_server.py`

Closes #22
