### PR TITLE
docs: remove agent-only guidance from public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,23 +151,6 @@ export MM_COMPETITOR_SHOP_ID=40319
 
 ## Основной workflow
 
-## Continuity и audit loop
-
-Перед каждой новой автономной итерацией нужно читать не только текущий код и roadmap, но и внешний audit-контур:
-
-1. `auditor_logs/issues.md`
-2. `auditor_logs/disagreements*.md`
-3. project memory в `.codex/memories/mm_market_tools_*.md`
-4. `ROADMAP.md`
-5. `CHANGELOG.md`
-
-Правила:
-
-- `issues.md` это не приказ, а слой внешней проверки;
-- `disagreements*.md` это официальный журнал обсуждения разногласий с аудитором;
-- если по `ISSUE` есть несогласие, оно должно быть зафиксировано именно в `disagreements*.md`, а не теряться в чате;
-- если `ISSUE` не берётся в текущую итерацию, он обязан остаться в `ROADMAP.md` и/или `CHANGELOG.md -> Unreleased`.
-
 ### A. Собрать всех продавцов по категории MM
 
 Пример для категории `Игрушки и игры`:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,16 +143,6 @@
 
 Если `ISSUE` не взят в текущую итерацию, он не должен пропадать. Он обязан остаться либо здесь, либо в `CHANGELOG.md` под `Unreleased`.
 
-### Audit loop policy
-
-- Перед новой автономной итерацией обязательно читать:
-  - `auditor_logs/issues.md`
-  - `auditor_logs/disagreements*.md`
-  - project memory в `.codex/memories/`
-- `Gemini`/auditor остаётся внешним audit/research слоем, а не управляющим проекта.
-- Если есть расхождение с `ISSUE`, решение фиксируется в `disagreements*.md`.
-- Код в проекте пишет только Codex; внешний audit используется как второе мнение и контроль качества.
-
 ### Carry-forward from auditor
 
 - `ISSUE-001`


### PR DESCRIPTION
## Summary

- remove the agent-only `Continuity и audit loop` section from `README.md`
- remove the agent-only `Audit loop policy` section from `ROADMAP.md`
- keep the remaining product/backlog content intact so this stays an atomic docs cleanup for issue `#19`

## Why

These sections describe internal agent coordination rather than the public/product-facing behavior of `mm-market-tools`. Keeping them in the main docs confuses readers and mixes framework/process guidance into the target repository.

## Scope

This PR intentionally does **not** mix in the larger path/docs cleanup from `#18`.

Related: `#19`

— Executor (Codex GPT-5)