### PR TITLE
cleanup: remove hardcoded home paths from pipeline defaults

### DIFF
--- a/build_cost_coverage_backlog.py
+++ b/build_cost_coverage_backlog.py
@@ -5,10 +5,11 @@ from collections import defaultdict
 from pathlib import Path
 
 from core.io_utils import load_json, write_json
+from core.paths import NORMALIZED_DIR, REPORTS_DIR
 
 
-DEFAULT_INPUT_JSON = "/home/user/mm-market-tools/data/normalized/competitor_market_analysis_2026-04-09g.json"
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
+DEFAULT_INPUT_JSON = str(NORMALIZED_DIR / "competitor_market_analysis_2026-04-09g.json")
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
 DEFAULT_DATE = dt.date.today().isoformat()
 
 

--- a/build_dynamic_pricing_report.py
+++ b/build_dynamic_pricing_report.py
@@ -10,7 +10,7 @@ from core.paths import DASHBOARD_DIR, REPORTS_DIR, ensure_dir, today_tag
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Build recommendation-first dynamic pricing report from market economics.")
-    parser.add_argument("--market-json", default="/home/user/mm-market-tools/data/dashboard/market_rescored_after_cogs_2026-04-09b.json")
+    parser.add_argument("--market-json", default=str(DASHBOARD_DIR / "market_rescored_after_cogs_2026-04-09b.json"))
     parser.add_argument("--report-dir", default=str(REPORTS_DIR))
     parser.add_argument("--dashboard-dir", default=str(DASHBOARD_DIR))
     parser.add_argument("--target-margin-pct", type=float, default=35.0)

--- a/build_market_margin_fit_report.py
+++ b/build_market_margin_fit_report.py
@@ -5,10 +5,11 @@ import datetime as dt
 from pathlib import Path
 
 from core.io_utils import load_json, write_json
+from core.paths import NORMALIZED_DIR, REPORTS_DIR
 
 
-DEFAULT_INPUT_JSON = "/home/user/mm-market-tools/data/normalized/competitor_market_analysis_2026-04-09g.json"
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
+DEFAULT_INPUT_JSON = str(NORMALIZED_DIR / "competitor_market_analysis_2026-04-09g.json")
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
 DEFAULT_DATE = dt.date.today().isoformat()
 
 

--- a/build_zero_cogs_registry.py
+++ b/build_zero_cogs_registry.py
@@ -8,12 +8,12 @@ from pathlib import Path
 from core.io_utils import load_json, write_json
 from core.market_analysis import classify_group
 from core.market_economics import load_cogs_override_rows
-from core.paths import COGS_OVERRIDES_PATH
+from core.paths import COGS_OVERRIDES_PATH, REPORTS_DIR
 
 
-DEFAULT_OFFICIAL_JSON = "/home/user/mm-market-tools/reports/official_period_analysis_2026-04-08.json"
-DEFAULT_BACKLOG_JSON = "/home/user/mm-market-tools/reports/cost_coverage_backlog_2026-04-09a.json"
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
+DEFAULT_OFFICIAL_JSON = str(REPORTS_DIR / "official_period_analysis_2026-04-08.json")
+DEFAULT_BACKLOG_JSON = str(REPORTS_DIR / "cost_coverage_backlog_2026-04-09a.json")
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
 DEFAULT_DATE = dt.date.today().isoformat()
 
 

--- a/core/paths.py
+++ b/core/paths.py
@@ -13,8 +13,8 @@ elif (_cwd.parent / "build_waybill_cost_layer.py").exists():
     # Запуск из подпапки
     PROJECT_ROOT = _cwd.parent
 else:
-    # Fallback на hardcoded path (для production)
-    PROJECT_ROOT = Path("/home/user/mm-market-tools")
+    # Fallback на расположение самого модуля, без машинно-зависимых путей.
+    PROJECT_ROOT = Path(__file__).resolve().parent.parent
 REPORTS_DIR = PROJECT_ROOT / "reports"
 DATA_DIR = PROJECT_ROOT / "data"
 SNAPSHOTS_DIR = DATA_DIR / "snapshots"

--- a/core/refresh_jobs.py
+++ b/core/refresh_jobs.py
@@ -87,7 +87,7 @@ JOB_DEFINITIONS = {
         "fields": [
             {"name": "category_id", "label": "Category ID", "type": "number", "default": "10162"},
             {"name": "page_size", "label": "Page size", "type": "number", "default": "50"},
-            {"name": "output_path", "label": "Output JSON", "type": "text", "default": "/home/user/mm_sellers_10162.json"},
+            {"name": "output_path", "label": "Output JSON", "type": "text", "default": str(REPORTS_DIR / "mm_sellers_10162.json")},
             {"name": "progress", "label": "Печатать прогресс", "type": "checkbox", "default": "true"},
         ],
     },
@@ -291,7 +291,7 @@ def build_job_command(job_key, form_data):
             "--page-size",
             str(form_data.get("page_size") or 50),
             "--output",
-            str(form_data.get("output_path") or "/home/user/mm_sellers_10162.json"),
+            str(form_data.get("output_path") or (REPORTS_DIR / "mm_sellers_10162.json")),
         ]
         if _bool(form_data.get("progress", "true")):
             command.append("--progress")

--- a/export_cogs_fill_template.py
+++ b/export_cogs_fill_template.py
@@ -5,10 +5,11 @@ import datetime as dt
 from pathlib import Path
 
 from core.io_utils import load_json
+from core.paths import REPORTS_DIR
 
 
-DEFAULT_REGISTRY_JSON = "/home/user/mm-market-tools/reports/zero_cogs_registry_2026-04-09a.json"
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
+DEFAULT_REGISTRY_JSON = str(REPORTS_DIR / "zero_cogs_registry_2026-04-09a.json")
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
 DEFAULT_DATE = dt.date.today().isoformat()
 
 

--- a/rescore_market_after_cogs_fill.py
+++ b/rescore_market_after_cogs_fill.py
@@ -13,13 +13,13 @@ from core.market_economics import (
     load_my_group_economics,
     merge_group_economics,
 )
-from core.paths import COGS_OVERRIDES_PATH, DASHBOARD_DIR, NORMALIZED_DIR, ensure_dir
+from core.paths import COGS_OVERRIDES_PATH, DASHBOARD_DIR, NORMALIZED_DIR, REPORTS_DIR, ensure_dir
 
 
-DEFAULT_MARKET_JSON = "/home/user/mm-market-tools/data/normalized/competitor_market_analysis_2026-04-09g.json"
-DEFAULT_OFFICIAL_JSON = "/home/user/mm-market-tools/reports/official_period_analysis_2026-04-08.json"
-DEFAULT_FILL_CSV = "/home/user/mm-market-tools/reports/cogs_fill_template_2026-04-09a.csv"
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
+DEFAULT_MARKET_JSON = str(NORMALIZED_DIR / "competitor_market_analysis_2026-04-09g.json")
+DEFAULT_OFFICIAL_JSON = str(REPORTS_DIR / "official_period_analysis_2026-04-08.json")
+DEFAULT_FILL_CSV = str(REPORTS_DIR / "cogs_fill_template_2026-04-09a.csv")
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
 DEFAULT_DATE = dt.date.today().isoformat()
 
 

--- a/run_cogs_backfill_cycle.py
+++ b/run_cogs_backfill_cycle.py
@@ -13,9 +13,9 @@ from ingest_cogs_fill import merge_rows
 
 
 DEFAULT_DATE = dt.date.today().isoformat()
-DEFAULT_OFFICIAL_JSON = "/home/user/mm-market-tools/reports/official_period_analysis_2026-04-08.json"
-DEFAULT_BACKLOG_JSON = "/home/user/mm-market-tools/reports/cost_coverage_backlog_2026-04-09a.json"
-DEFAULT_MARKET_JSON = "/home/user/mm-market-tools/data/normalized/competitor_market_analysis_2026-04-09g.json"
+DEFAULT_OFFICIAL_JSON = str(REPORTS_DIR / "official_period_analysis_2026-04-08.json")
+DEFAULT_BACKLOG_JSON = str(REPORTS_DIR / "cost_coverage_backlog_2026-04-09a.json")
+DEFAULT_MARKET_JSON = str(NORMALIZED_DIR / "competitor_market_analysis_2026-04-09g.json")
 
 
 def parse_args():


### PR DESCRIPTION
## Summary

- replace machine-specific `/home/user/mm-market-tools` defaults in the COGS/pricing pipeline scripts with project-relative defaults from `core.paths`
- remove the hardcoded `/home/user/mm-market-tools` fallback from `core/paths.py`
- update the `sellers_scan` default output path in `core/refresh_jobs.py` to a repo-relative reports path

## Scope

This is an **atomic partial cleanup** for issue `#18`.
It intentionally covers only executable pipeline defaults in these files:

- `core/paths.py`
- `core/refresh_jobs.py`
- `build_dynamic_pricing_report.py`
- `build_cost_coverage_backlog.py`
- `build_market_margin_fit_report.py`
- `build_zero_cogs_registry.py`
- `export_cogs_fill_template.py`
- `rescore_market_after_cogs_fill.py`
- `run_cogs_backfill_cycle.py`

It does **not** yet include:
- README examples
- smoke tests / fixtures
- historical JSON/report artifacts
- market research scripts like `analyze_*` and `compare_*`

## Verification

- `rg -n "/home/user/"` on the touched files returns no matches
- `python3 -m py_compile` passed for all touched Python files

Related: `#18`

— Executor (Codex GPT-5)