### PR TITLE
cleanup: remove hardcoded home paths from smoke/report defaults

### DIFF
--- a/build_price_trap_report.py
+++ b/build_price_trap_report.py
@@ -3,7 +3,7 @@ import argparse
 from pathlib import Path
 
 from core.io_utils import load_json, write_json
-from core.paths import REPORTS_DIR, ensure_dir, today_tag
+from core.paths import NORMALIZED_DIR, REPORTS_DIR, ensure_dir, today_tag
 
 
 DEFAULT_THRESHOLDS = [99, 149, 199, 299, 399, 499, 799, 999, 1499, 1999]
@@ -15,7 +15,7 @@ def parse_args():
     )
     parser.add_argument(
         "--input-json",
-        default="/home/user/mm-market-tools/data/normalized/weekly_operational_report_2026-04-08.json",
+        default=str(NORMALIZED_DIR / "weekly_operational_report_2026-04-08.json"),
     )
     parser.add_argument("--report-dir", default=str(REPORTS_DIR))
     parser.add_argument("--report-prefix", default=f"price_trap_report_{today_tag()}")

--- a/build_title_seo_report.py
+++ b/build_title_seo_report.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 
 from core.io_utils import load_json, write_json
-from core.paths import REPORTS_DIR, ensure_dir, today_tag
+from core.paths import NORMALIZED_DIR, REPORTS_DIR, ensure_dir, today_tag
 
 
 STOPWORDS = {
@@ -55,7 +55,7 @@ def parse_args():
     )
     parser.add_argument(
         "--input-json",
-        default="/home/user/mm-market-tools/data/normalized/weekly_operational_report_2026-04-08.json",
+        default=str(NORMALIZED_DIR / "weekly_operational_report_2026-04-08.json"),
     )
     parser.add_argument("--report-dir", default=str(REPORTS_DIR))
     parser.add_argument("--report-prefix", default=f"title_seo_report_{today_tag()}")

--- a/smoke_test_market_pipeline.py
+++ b/smoke_test_market_pipeline.py
@@ -3,12 +3,14 @@ import argparse
 import json
 from pathlib import Path
 
+from core.paths import DASHBOARD_DIR
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Smoke test for competitor market dashboard bundle.")
     parser.add_argument(
         "--dashboard-json",
-        default="/home/user/mm-market-tools/data/dashboard/competitor_market_analysis_2026-04-08d.json",
+        default=str(DASHBOARD_DIR / "competitor_market_analysis_2026-04-08d.json"),
     )
     return parser.parse_args()
 

--- a/smoke_test_marketing_card_audit.py
+++ b/smoke_test_marketing_card_audit.py
@@ -3,13 +3,14 @@ import argparse
 from pathlib import Path
 
 from core.io_utils import load_json
+from core.paths import DASHBOARD_DIR
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Smoke-test unified marketing card audit dashboard bundle.")
     parser.add_argument(
         "--dashboard-json",
-        default="/home/user/mm-market-tools/data/dashboard/marketing_card_audit_2026-04-10.json",
+        default=str(DASHBOARD_DIR / "marketing_card_audit_2026-04-10.json"),
     )
     return parser.parse_args()
 

--- a/smoke_test_price_trap_report.py
+++ b/smoke_test_price_trap_report.py
@@ -3,12 +3,14 @@ import argparse
 import json
 from pathlib import Path
 
+from core.paths import REPORTS_DIR
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Smoke test for price trap marketing report.")
     parser.add_argument(
         "--report-json",
-        default="/home/user/mm-market-tools/reports/price_trap_report_2026-04-10.json",
+        default=str(REPORTS_DIR / "price_trap_report_2026-04-10.json"),
     )
     return parser.parse_args()
 

--- a/smoke_test_pricing_pipeline.py
+++ b/smoke_test_pricing_pipeline.py
@@ -3,12 +3,14 @@ import argparse
 import json
 from pathlib import Path
 
+from core.paths import DASHBOARD_DIR
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Smoke test for dynamic pricing dashboard bundle.")
     parser.add_argument(
         "--dashboard-json",
-        default="/home/user/mm-market-tools/data/dashboard/dynamic_pricing_2026-04-10.json",
+        default=str(DASHBOARD_DIR / "dynamic_pricing_2026-04-10.json"),
     )
     return parser.parse_args()
 

--- a/smoke_test_title_seo_report.py
+++ b/smoke_test_title_seo_report.py
@@ -3,12 +3,14 @@ import argparse
 import json
 from pathlib import Path
 
+from core.paths import REPORTS_DIR
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Smoke test for title SEO report.")
     parser.add_argument(
         "--report-json",
-        default="/home/user/mm-market-tools/reports/title_seo_report_2026-04-10.json",
+        default=str(REPORTS_DIR / "title_seo_report_2026-04-10.json"),
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary

- replace machine-specific `/home/user/mm-market-tools` defaults in the smoke-test scripts with project-relative defaults from `core.paths`
- remove the same hardcoded input defaults from `build_title_seo_report.py` and `build_price_trap_report.py`
- keep this chunk limited to the smoke/defaults and adjacent marketing-report layer for issue `#18`

## Scope

This PR intentionally covers only:

- `smoke_test_pricing_pipeline.py`
- `smoke_test_market_pipeline.py`
- `smoke_test_title_seo_report.py`
- `smoke_test_price_trap_report.py`
- `smoke_test_marketing_card_audit.py`
- `build_title_seo_report.py`
- `build_price_trap_report.py`

It does **not** yet include README examples, historical artifacts, or the broader market-research script tail.

## Verification

- `python3 -m py_compile` passed for all touched files
- `rg -n "/home/user/"` on the touched files returns no matches
- `python3 smoke_test_pricing_pipeline.py`
- `python3 smoke_test_market_pipeline.py`
- `python3 smoke_test_title_seo_report.py`
- `python3 smoke_test_price_trap_report.py`
- `python3 smoke_test_marketing_card_audit.py`

Related: `#18`

— Executor (Codex GPT-5)