### PR TITLE
cleanup: remove hardcoded home paths from analysis defaults

### DIFF
--- a/analyze_competitor_market.py
+++ b/analyze_competitor_market.py
@@ -17,7 +17,7 @@ from core.market_analysis import (
 from core.market_dashboard import build_market_dashboard
 from core.market_economics import apply_market_margin_fit, load_cogs_override_rows, load_my_group_economics, merge_group_economics
 from core.io_utils import write_json
-from core.paths import COGS_OVERRIDES_PATH, DASHBOARD_DIR, NORMALIZED_DIR, ensure_dir
+from core.paths import COGS_OVERRIDES_PATH, DASHBOARD_DIR, NORMALIZED_DIR, REPORTS_DIR, ensure_dir
 from core.market_crosstab import (
     calculate_hhi_by_band,
     build_group_price_band_crosstab,
@@ -30,11 +30,11 @@ from core.market_crosstab import (
 
 SEARCH_URL = "https://web-api.mm.ru/v2/goods/search"
 DEFAULT_CATEGORY_ID = 10162
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
 DEFAULT_DATE = dt.date.today().isoformat()
-DEFAULT_TOP_SELLERS_JSON = "/home/user/mm_sellers_10162.json"
-DEFAULT_MY_PRODUCTS_CSV = "/home/user/mm-market-tools/reports/my_shop_top_products.csv"
-DEFAULT_OFFICIAL_REPORT_JSON = "/home/user/mm-market-tools/reports/official_period_analysis_2026-04-08.json"
+DEFAULT_TOP_SELLERS_JSON = str(REPORTS_DIR / "mm_sellers_10162.json")
+DEFAULT_MY_PRODUCTS_CSV = str(REPORTS_DIR / "my_shop_top_products.csv")
+DEFAULT_OFFICIAL_REPORT_JSON = str(REPORTS_DIR / "official_period_analysis_2026-04-08.json")
 DEFAULT_PRICE_BAND_BOUNDARIES = [50, 200, 500]  # Results in: 0-50, 50-200, 200-500, 500+
 
 def search_page(session, category_id, limit, offset):

--- a/analyze_product_ideas.py
+++ b/analyze_product_ideas.py
@@ -9,14 +9,15 @@ from pathlib import Path
 
 from core.http_client import build_mm_public_headers, create_session, request_json
 from core.market_analysis import classify_group, idea_fingerprint
+from core.paths import REPORTS_DIR
 
 
 SEARCH_URL = "https://web-api.mm.ru/v2/goods/search"
 PRODUCT_URL = "https://api.kazanexpress.ru/api/v2/product/{product_id}"
 DEFAULT_CATEGORY_ID = 10162
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
-DEFAULT_MY_PRODUCTS_CSV = "/home/user/mm-market-tools/reports/my_shop_top_products.csv"
-DEFAULT_TOP_SELLERS_JSON = "/home/user/mm_sellers_10162.json"
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
+DEFAULT_MY_PRODUCTS_CSV = str(REPORTS_DIR / "my_shop_top_products.csv")
+DEFAULT_TOP_SELLERS_JSON = str(REPORTS_DIR / "mm_sellers_10162.json")
 DEFAULT_DATE = dt.date.today().isoformat()
 DEFAULT_REAL_COMPETITORS = [16685, 40319, 28064, 16100, 17382, 36530]
 STOPWORDS = {

--- a/analyze_time_window.py
+++ b/analyze_time_window.py
@@ -6,9 +6,11 @@ import json
 import math
 from pathlib import Path
 
+from core.paths import REPORTS_DIR, SNAPSHOTS_DIR
 
-DEFAULT_SNAPSHOT_DIR = "/home/user/mm-market-tools/data/snapshots"
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
+
+DEFAULT_SNAPSHOT_DIR = str(SNAPSHOTS_DIR)
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
 
 
 def load_snapshot(path):

--- a/benchmark_product_cards.py
+++ b/benchmark_product_cards.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from core.auth import bearer_headers
 from core.http_client import build_mm_public_headers, create_session, request_json
+from core.paths import REPORTS_DIR
 
 
 MM_SEARCH_URL = "https://web-api.mm.ru/v2/goods/search"
@@ -20,8 +21,8 @@ SELLER_PRODUCTS_URL = (
     "https://api.business.kazanexpress.ru/api/seller/shop/{shop_id}/product/getProducts"
 )
 DEFAULT_CATEGORY_ID = 10162
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
-DEFAULT_MY_PRODUCTS_CSV = "/home/user/mm-market-tools/reports/my_shop_top_products.csv"
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
+DEFAULT_MY_PRODUCTS_CSV = str(REPORTS_DIR / "my_shop_top_products.csv")
 DEFAULT_REPORT_PREFIX = f"product_card_benchmark_{dt.date.today().isoformat()}"
 STOPWORDS = {
     "для",

--- a/build_growth_plan.py
+++ b/build_growth_plan.py
@@ -5,9 +5,11 @@ import json
 from collections import Counter, defaultdict
 from pathlib import Path
 
+from core.paths import REPORTS_DIR
+
 
 DEFAULT_DATE = dt.date.today().isoformat()
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
 
 
 def load_json(path):

--- a/compare_top_seller_overlaps.py
+++ b/compare_top_seller_overlaps.py
@@ -13,6 +13,7 @@ import requests
 
 from core.auth import bearer_headers
 from core.http_client import build_mm_public_headers, create_session, request_json
+from core.paths import REPORTS_DIR
 
 
 ROOT_CATEGORIES_URL = "https://api.kazanexpress.ru/api/category/v2/root-categories"
@@ -24,9 +25,9 @@ SELLER_PRODUCTS_URL = (
 )
 DEFAULT_CATEGORY_ID = 10162
 DEFAULT_MY_SHOP_ID = 98
-DEFAULT_TOP_SELLERS_JSON = "/home/user/mm_sellers_10162.json"
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
-DEFAULT_MY_PRODUCTS_CSV = "/home/user/mm-market-tools/reports/my_shop_top_products.csv"
+DEFAULT_TOP_SELLERS_JSON = str(REPORTS_DIR / "mm_sellers_10162.json")
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
+DEFAULT_MY_PRODUCTS_CSV = str(REPORTS_DIR / "my_shop_top_products.csv")
 DEFAULT_SORT = {"type": "popularity", "order": "desc"}
 DEFAULT_PAGE_SIZE = 50
 DEFAULT_REPORT_PREFIX = f"top10_overlap_report_{dt.date.today().isoformat()}"

--- a/cubejs_query.py
+++ b/cubejs_query.py
@@ -8,10 +8,11 @@ import urllib.parse
 from pathlib import Path
 
 from core.cubejs_api import flatten_results, run_cubejs_query
+from core.paths import REPORTS_DIR
 
 
 DEFAULT_BASE_URL = "https://seller-analytics.mm.ru/cubejs-api/v1/load"
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
 
 
 def parse_date_range(value):

--- a/request_document_report.py
+++ b/request_document_report.py
@@ -10,10 +10,11 @@ from core.auth import require_access_token
 from core.dates import parse_moscow_datetime, to_epoch_ms
 from core.documents_api import create_request, fetch_requests
 from core.http_client import create_session, download_bytes
+from core.paths import REPORTS_DIR
 
 
 DEFAULT_BASE_URL = "https://api.business.kazanexpress.ru/api/seller/documents"
-DEFAULT_REPORT_DIR = "/home/user/mm-market-tools/reports"
+DEFAULT_REPORT_DIR = str(REPORTS_DIR)
 
 
 def find_request(requests_payload, request_id):

--- a/snapshot_shop.py
+++ b/snapshot_shop.py
@@ -10,11 +10,12 @@ from pathlib import Path
 
 from core.auth import bearer_headers, require_access_token
 from core.http_client import create_session, request_json
+from core.paths import SNAPSHOTS_DIR
 
 
 DEFAULT_TIMEOUT = 20
 DEFAULT_PAGE_SIZE = 100
-DEFAULT_SNAPSHOT_DIR = "/home/user/mm-market-tools/data/snapshots"
+DEFAULT_SNAPSHOT_DIR = str(SNAPSHOTS_DIR)
 
 def seller_headers(token):
     return bearer_headers(token)


### PR DESCRIPTION
## Summary

- replace machine-specific `/home/user/...` defaults in the standalone analysis/report scripts with project-relative defaults from `core.paths`
- normalize default paths for reports, snapshots, and seller-list inputs in the CLI layer
- keep this chunk limited to the standalone analysis/report script layer for issue `#18`

## Scope

This PR intentionally covers only:

- `analyze_competitor_market.py`
- `analyze_product_ideas.py`
- `compare_top_seller_overlaps.py`
- `benchmark_product_cards.py`
- `build_growth_plan.py`
- `cubejs_query.py`
- `request_document_report.py`
- `analyze_time_window.py`
- `snapshot_shop.py`

It does **not** include smoke/fixture files, README examples, or workflow files.

## Verification

- `python3 -m py_compile` passed for all touched files
- `rg -n "/home/user/"` on the touched files returns no matches
- `python3 analyze_time_window.py --help`
- `python3 cubejs_query.py --help`

Related: `#18`

— Executor (Codex GPT-5)