### PR TITLE
cleanup: remove hardcoded home paths from tooling defaults

### DIFF
--- a/get_sellers.py
+++ b/get_sellers.py
@@ -7,6 +7,7 @@ import time
 from collections import Counter
 
 from core.http_client import build_mm_public_headers, create_session, request_json
+from core.paths import REPORTS_DIR
 
 
 ROOT_CATEGORIES_URL = "https://api.kazanexpress.ru/api/category/v2/root-categories"
@@ -385,7 +386,7 @@ def parse_args():
     parser.add_argument("--category-id", type=int, default=DEFAULT_CATEGORY_ID)
     parser.add_argument("--page-size", type=int, default=DEFAULT_PAGE_SIZE)
     parser.add_argument("--sleep", type=float, default=DEFAULT_SLEEP_SECONDS)
-    parser.add_argument("--output", default="/home/user/mm_sellers_10162.json")
+    parser.add_argument("--output", default=str(REPORTS_DIR / "mm_sellers_10162.json"))
     parser.add_argument("--progress", action="store_true")
     return parser.parse_args()
 

--- a/migrate_dashboard_schema.py
+++ b/migrate_dashboard_schema.py
@@ -4,11 +4,12 @@ import json
 from pathlib import Path
 
 from core.dashboard_schema import DASHBOARD_SCHEMA_VERSION
+from core.paths import DASHBOARD_DIR
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Backfill schema_version into existing dashboard bundles.")
-    parser.add_argument("--dashboard-dir", default="/home/user/mm-market-tools/data/dashboard")
+    parser.add_argument("--dashboard-dir", default=str(DASHBOARD_DIR))
     return parser.parse_args()
 
 

--- a/smoke_test_description_seo_richness_report.py
+++ b/smoke_test_description_seo_richness_report.py
@@ -5,6 +5,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+PROJECT_ROOT = Path(__file__).resolve().parent
+
 
 def main():
     parser = argparse.ArgumentParser(description="Smoke test for description SEO richness dashboard bundle.")
@@ -31,7 +33,7 @@ def main():
 
         cmd = [
             "python3",
-            "/home/user/mm-market-tools/build_description_seo_richness_report.py",
+            str(PROJECT_ROOT / "build_description_seo_richness_report.py"),
             "--input-json",
             str(input_json),
             "--cache-json",

--- a/smoke_test_entity_history_index.py
+++ b/smoke_test_entity_history_index.py
@@ -1,22 +1,56 @@
 #!/usr/bin/env python3
 import argparse
+import json
+import subprocess
+import tempfile
 from pathlib import Path
 
 from core.io_utils import load_json
 
+PROJECT_ROOT = Path(__file__).resolve().parent
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Smoke-test entity history index for dashboard drilldown.")
-    parser.add_argument(
-        "--entity-history-json",
-        default="/home/user/mm-market-tools/data/local/entity_history_index.json",
-    )
     return parser.parse_args()
 
 
 def main():
-    args = parse_args()
-    payload = load_json(Path(args.entity_history_json))
+    parse_args()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        dashboard_dir = tmp_path / "dashboard"
+        output_json = tmp_path / "entity_history_index.json"
+        dashboard_dir.mkdir(parents=True, exist_ok=True)
+        fixture = {
+            "generated_at": "2026-04-13T00:00:00Z",
+            "tables": {
+                "priority_cards": [
+                    {
+                        "key": "sku-1",
+                        "product_id": 101,
+                        "title": "Пазл Три кота",
+                        "seo_status": "needs_work",
+                        "price_trap": True,
+                    }
+                ]
+            },
+        }
+        (dashboard_dir / "marketing_card_audit_fixture.json").write_text(
+            json.dumps(fixture, ensure_ascii=False), encoding="utf-8"
+        )
+        subprocess.run(
+            [
+                "python3",
+                str(PROJECT_ROOT / "build_entity_history_index.py"),
+                "--dashboard-dir",
+                str(dashboard_dir),
+                "--output",
+                str(output_json),
+            ],
+            check=True,
+        )
+        payload = load_json(output_json)
     assert payload.get("schema_version"), "missing schema_version"
     assert "entity_count" in payload, "missing entity_count"
     assert "entities" in payload, "missing entities"

--- a/smoke_test_media_richness_report.py
+++ b/smoke_test_media_richness_report.py
@@ -5,6 +5,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+PROJECT_ROOT = Path(__file__).resolve().parent
+
 
 def main():
     parser = argparse.ArgumentParser(description="Smoke test for media richness dashboard bundle.")
@@ -31,7 +33,7 @@ def main():
 
         cmd = [
             "python3",
-            "/home/user/mm-market-tools/build_media_richness_report.py",
+            str(PROJECT_ROOT / "build_media_richness_report.py"),
             "--input-json",
             str(input_json),
             "--cache-json",

--- a/smoke_test_waybill_cost_layer.py
+++ b/smoke_test_waybill_cost_layer.py
@@ -1,22 +1,43 @@
 #!/usr/bin/env python3
+import json
 from pathlib import Path
 import subprocess
+import tempfile
 
-
-SYNTHETIC_INPUT = Path('/home/user/mm-market-tools/data/local/waybill_synthetic_sample.json')
+PROJECT_ROOT = Path(__file__).resolve().parent
 
 
 def main():
-    result = subprocess.run([
-        'python3',
-        '/home/user/mm-market-tools/build_waybill_cost_layer.py',
-        '--input-json', str(SYNTHETIC_INPUT),
-        '--report-prefix', 'waybill_cost_layer_smoke_2026-04-13'
-    ], capture_output=True, text=True)
-    print(result.stdout)
-    if result.returncode != 0:
-        print(result.stderr)
-        raise SystemExit(result.returncode)
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        input_json = tmp_path / "waybill_synthetic_sample.json"
+        payload = {
+            "sheet_name": "synthetic_waybill",
+            "rows": [
+                {
+                    "штрихкод": "460000000001",
+                    "себестоимость": 123.45,
+                    "количество": 2,
+                    "товар": "Пазл Три кота",
+                    "артикул": "SKU-1",
+                    "waybill id": "WB-1",
+                }
+            ],
+        }
+        input_json.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        result = subprocess.run([
+            'python3',
+            str(PROJECT_ROOT / 'build_waybill_cost_layer.py'),
+            '--input-json', str(input_json),
+            '--report-dir', str(tmp_path / 'reports'),
+            '--normalized-dir', str(tmp_path / 'normalized'),
+            '--dashboard-dir', str(tmp_path / 'dashboard'),
+            '--report-prefix', 'waybill_cost_layer_smoke_2026-04-13'
+        ], capture_output=True, text=True)
+        print(result.stdout)
+        if result.returncode != 0:
+            print(result.stderr)
+            raise SystemExit(result.returncode)
     print('SMOKE_WAYBILL_COST_LAYER_OK')
 
 


### PR DESCRIPTION
## Summary

- replace machine-specific `/home/user/...` defaults in the remaining tooling/smoke-fixture layer with project-relative defaults
- make the entity-history and waybill smoke tests self-contained by generating temporary synthetic fixtures instead of depending on untracked local files
- keep this chunk limited to the tooling/smoke-fixture layer for issue `#18`

## Scope

This PR intentionally covers only:

- `get_sellers.py`
- `migrate_dashboard_schema.py`
- `smoke_test_entity_history_index.py`
- `smoke_test_waybill_cost_layer.py`
- `smoke_test_media_richness_report.py`
- `smoke_test_description_seo_richness_report.py`

## Verification

- `python3 -m py_compile` passed for all touched files
- `python3 smoke_test_entity_history_index.py`
- `python3 smoke_test_waybill_cost_layer.py`
- `python3 smoke_test_media_richness_report.py`
- `python3 smoke_test_description_seo_richness_report.py`
- `python3 get_sellers.py --help`
- `rg -n "/home/user/"` on the touched files returns no matches

Related: `#18`

— Executor (Codex GPT-5)