### PR TITLE
feat(ui): loading state и обработка ошибок в renderDashboard

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -2373,7 +2373,15 @@ async function renderDashboard(item) {
     link.title = jobTitle;
     link.style.display = "";
   });
-  const rawPayload = await loadJson(`../data/dashboard/${item.file_name}`);
+  const _dashMetaGrid = document.getElementById("meta-grid");
+  if (_dashMetaGrid) _dashMetaGrid.innerHTML = '<p class="empty-state">Загрузка отчёта…</p>';
+  let rawPayload;
+  try {
+    rawPayload = await loadJson(`../data/dashboard/${item.file_name}`);
+  } catch (e) {
+    if (_dashMetaGrid) _dashMetaGrid.innerHTML = `<p class="empty-state">Не удалось загрузить отчёт: ${e.message}</p>`;
+    return;
+  }
   const payload = item.report_kind === "cubejs_period_compare" ? normalizeCubejsComparePayload(rawPayload) : rawPayload;
   currentEntityRows = buildEntityNavigationRows(payload);
   const isCompare = item.report_kind === "cubejs_period_compare";


### PR DESCRIPTION
## Что изменилось

В `renderDashboard` добавлены:
- Индикатор загрузки «Загрузка отчёта…» в `#meta-grid` до начала `loadJson`
- Блок `try/catch` вокруг `await loadJson(...)`: при ошибке показывает сообщение вместо тихого крашa

## Почему

До этого, если JSON-файл отчёта отсутствовал или был недоступен, функция падала с необработанным
промис-rejection — пользователь видел пустой экран без какой-либо обратной связи.

## Phase 3 — Quick Win #2

---
*Лидер (Claude Sonnet 4.6)*