### PR TITLE
feat(ui): error state при отсутствии индекса отчётов

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -2851,7 +2851,14 @@ async function init() {
   decorateStaticPanelInfos();
   document.getElementById("refresh-link-top")?.setAttribute("href", refreshUiUrl());
   document.getElementById("refresh-link-bottom")?.setAttribute("href", refreshUiUrl());
-  const index = await loadDashboardIndex();
+  let index;
+  try {
+    index = await loadDashboardIndex();
+  } catch (e) {
+    const _initMetaGrid = document.getElementById("meta-grid");
+    if (_initMetaGrid) _initMetaGrid.innerHTML = `<p class="empty-state">Не удалось загрузить индекс отчётов: ${e.message}. Запустите <code>build_dashboard_index.py</code>.</p>`;
+    return;
+  }
   entityHistoryIndex = await loadEntityHistoryIndex().catch(() => ({ entities: [] }));
   cogsOverrideStore = await loadLocalCogsStore().catch(() => null);
   const select = document.getElementById("report-select");


### PR DESCRIPTION
## Что изменилось

В `init()` добавлен `try/catch` вокруг `await loadDashboardIndex()`:
- При ошибке загрузки индекса показывается сообщение с причиной и подсказкой запустить `build_dashboard_index.py`
- Вместо белого экрана пользователь получает понятную инструкцию

## Почему

При отсутствии `data/dashboard/index.json` (новая установка, удалённые данные)
`init()` бросал необработанный Promise rejection — пустой белый экран без объяснений.

## Phase 3 — Quick Win #3

---
*Лидер (Claude Sonnet 4.6)*