### PR TITLE
fix(refresh): обработка ошибок при поллинге активного запуска

### DIFF
--- a/ui/refresh.js
+++ b/ui/refresh.js
@@ -727,7 +727,13 @@ async function refreshActiveRun() {
     log.textContent = "Нет активного запуска.";
     return;
   }
-  const payload = await loadJson(`/api/run?job_id=${encodeURIComponent(activeJobId)}`);
+  let payload;
+  try {
+    payload = await loadJson(`/api/run?job_id=${encodeURIComponent(activeJobId)}`);
+  } catch (e) {
+    log.textContent = `Ошибка поллинга: ${e.message}`;
+    return;
+  }
   renderRunMeta(payload.status);
   await renderResultSummary(payload.status);
   log.textContent = payload.log || "Лог пока пуст.";


### PR DESCRIPTION
## Что изменилось

В `refreshActiveRun` добавлен `try/catch` вокруг `await loadJson(...)` для получения статуса запуска:
- При ошибке (сервер недоступен, таймаут) показывается сообщение `Ошибка поллинга: <причина>` в логе
- Функция завершается вместо того, чтобы крашить без обратной связи

## Почему

Функция вызывается из `setTimeout` без `.catch()`. Если сервер уходит вниз
во время работающего job, polling тихо падал — пользователь видел зависший лог
без объяснений.

## Phase 3 — Quick Win #4

---
*Лидер (Claude Sonnet 4.6)*