### PR TITLE
fix(ui): исправлен селектор кнопки reload в loadBuyerReviews

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -2805,7 +2805,7 @@ async function loadBuyerReviews() {
   const root = document.getElementById("buyer-reviews-list");
   if (!root) return;
   root.innerHTML = '<p class="empty-state">Загрузка отзывов…</p>';
-  const reloadBtn = document.querySelector("#buyer-reviews-wrap .compact-button");
+  const reloadBtn = document.querySelector("#buyer-reviews-toolbar .compact-button");
   if (reloadBtn) { reloadBtn.disabled = true; reloadBtn.textContent = "Загрузка…"; }
   try {
     const resp = await fetch("/api/reviews");


### PR DESCRIPTION
## Проблема

PR #53 добавил selector `#buyer-reviews-wrap .compact-button` для кнопки «Обновить список»,
но элемента `#buyer-reviews-wrap` в HTML не существует — кнопка находится
в `#buyer-reviews-toolbar`. Из-за этого `reloadBtn` всегда равен `null`
и блокировка кнопки во время загрузки не работала.

## Исправление

Заменён селектор: `#buyer-reviews-wrap` → `#buyer-reviews-toolbar`.

---
*Лидер (Claude Sonnet 4.6)*