### PR TITLE
feat(ui): empty state в insights grid при отсутствии данных

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -626,7 +626,12 @@ function renderMarketingKpis(payload) {
 function renderInsights(items) {
   const root = document.getElementById("insights-grid");
   root.innerHTML = "";
-  (items || []).forEach((item) => {
+  const list = items || [];
+  if (!list.length) {
+    root.append(el("p", "empty-state", "Аналитических инсайтов нет."));
+    return;
+  }
+  list.forEach((item) => {
     const card = el("div", "insight-card");
     if (item.tone) {
       card.dataset.tone = item.tone;


### PR DESCRIPTION
## Что изменилось

В `renderInsights` добавлен empty state: если массив инсайтов пуст, показывается «Аналитических инсайтов нет.» вместо пустой секции.

## Почему

Раньше при отсутствии инсайтов `#insights-grid` просто оставался пустым — пользователь не понимал, загрузились ли данные или их действительно нет.

## Phase 3 — Quick Win #7

---
*Лидер (Claude Sonnet 4.6)*