### PR TITLE
feat(ui): loading state в панелях центра действий

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -969,6 +969,12 @@ function buildEntityPayload(row, context) {
 }
 
 async function refreshActionCenter() {
+  const _acWatchRoot = document.getElementById("watchlist-panel");
+  const _acActionsRoot = document.getElementById("manual-actions-panel");
+  const _acStatusRoot = document.getElementById("action-center-status-panel");
+  [_acWatchRoot, _acActionsRoot, _acStatusRoot].forEach((root) => {
+    if (root) root.innerHTML = '<p class="empty-state">Загрузка…</p>';
+  });
   actionCenterState = await loadActionCenter();
   renderActionCenter();
   renderManagerQueues();


### PR DESCRIPTION
## Что изменилось

В `refreshActionCenter` добавлен loading state:
- До начала `loadActionCenter()` все три панели (watchlist, manual-actions, status) показывают «Загрузка…»
- Это особенно важно когда runner недоступен и `fetchJsonWithFallback` перебирает 4 кандидата — пользователь видит пустые панели 3–5 секунд

## Phase 3 — Quick Win #8

---
*Лидер (Claude Sonnet 4.6)*