### PR TITLE
fix(refresh): обработка ошибки index при рендере артефактов

### DIFF
--- a/ui/refresh.js
+++ b/ui/refresh.js
@@ -253,7 +253,12 @@ async function renderResultSummary(status) {
 
   const artifacts = status.artifacts || [];
   if (!artifacts.length) return;
-  const indexPayload = await loadDashboardIndex();
+  let indexPayload;
+  try {
+    indexPayload = await loadDashboardIndex();
+  } catch {
+    indexPayload = { items: [] };
+  }
   artifacts.slice(0, 6).forEach((artifact) => {
     const dashboardMatch = findDashboardMatch(indexPayload, artifact);
     const card = el("div", "insight-card artifact-summary-card");


### PR DESCRIPTION
## Проблема

`renderResultSummary` вызывает `await loadDashboardIndex()` без try/catch. Если `data/dashboard/index.json` не существует (свежая установка, нет данных), функция бросает необработанный rejection при попытке показать ссылки на артефакты.

## Исправление

Обёрнуто в try/catch: при ошибке `indexPayload = { items: [] }` — артефакты показываются без привязки к dashboard.

---
*Лидер (Claude Sonnet 4.6)*